### PR TITLE
Fix ffmpeg dependency for wizard progression

### DIFF
--- a/Aura.Web/src/components/Onboarding/FFmpegDependencyCard.tsx
+++ b/Aura.Web/src/components/Onboarding/FFmpegDependencyCard.tsx
@@ -75,11 +75,13 @@ const useStyles = makeStyles({
 export interface FFmpegDependencyCardProps {
   onInstallComplete?: () => void;
   autoCheck?: boolean;
+  autoExpandDetails?: boolean;
 }
 
 export function FFmpegDependencyCard({
   onInstallComplete,
   autoCheck = true,
+  autoExpandDetails = false,
 }: FFmpegDependencyCardProps) {
   const styles = useStyles();
   const [status, setStatus] = useState<FFmpegStatus | null>(null);
@@ -87,7 +89,7 @@ export function FFmpegDependencyCard({
   const [isInstalling, setIsInstalling] = useState(false);
   const [installProgress, setInstallProgress] = useState(0);
   const [error, setError] = useState<string | null>(null);
-  const [showDetails, setShowDetails] = useState(false);
+  const [showDetails, setShowDetails] = useState(autoExpandDetails);
 
   const checkStatus = async () => {
     setIsLoading(true);
@@ -142,6 +144,13 @@ export function FFmpegDependencyCard({
     // Intentionally only run on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoCheck]);
+
+  // Auto-expand details if FFmpeg is not ready and autoExpandDetails is true
+  useEffect(() => {
+    if (autoExpandDetails && status && (!status.installed || !status.valid || !status.version)) {
+      setShowDetails(true);
+    }
+  }, [status, autoExpandDetails]);
 
   const handleInstall = async () => {
     setIsInstalling(true);

--- a/Aura.Web/src/pages/Onboarding/FirstRunWizard.tsx
+++ b/Aura.Web/src/pages/Onboarding/FirstRunWizard.tsx
@@ -234,14 +234,8 @@ export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
 
     // Step 1: FFmpeg Installation -> Step 2: Provider Configuration
     if (state.step === 1) {
-      // Must have FFmpeg installed to proceed
-      if (!ffmpegReady) {
-        showFailureToast({
-          title: 'FFmpeg Required',
-          message: 'Please install FFmpeg before continuing. It is required for video generation.',
-        });
-        return;
-      }
+      // Allow proceeding even without FFmpeg (user can skip)
+      // The warning is already shown in the UI
       dispatch({ type: 'SET_STEP', payload: 2 });
       return;
     }
@@ -424,6 +418,7 @@ export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
 
       <FFmpegDependencyCard
         autoCheck={true}
+        autoExpandDetails={true}
         onInstallComplete={async () => {
           setFfmpegReady(true);
           dispatch({ type: 'INSTALL_COMPLETE', payload: 'ffmpeg' });
@@ -439,6 +434,54 @@ export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
           }
         }}
       />
+
+      {!ffmpegReady && (
+        <Card
+          style={{
+            padding: tokens.spacingVerticalL,
+            backgroundColor: tokens.colorPaletteYellowBackground1,
+            borderLeft: `4px solid ${tokens.colorPaletteYellowBorder1}`,
+          }}
+        >
+          <Text
+            weight="semibold"
+            style={{ display: 'flex', alignItems: 'center', gap: tokens.spacingHorizontalS }}
+          >
+            <Warning24Regular /> Want to install FFmpeg manually?
+          </Text>
+          <Text style={{ display: 'block', marginTop: tokens.spacingVerticalS }}>
+            If you prefer to install FFmpeg yourself or already have it installed, you can skip this
+            step. However, video generation will not work until FFmpeg is properly installed.
+          </Text>
+          <div
+            style={{
+              marginTop: tokens.spacingVerticalM,
+              display: 'flex',
+              gap: tokens.spacingHorizontalS,
+            }}
+          >
+            <Button
+              appearance="secondary"
+              onClick={() => {
+                if (
+                  window.confirm(
+                    'Are you sure you want to skip FFmpeg installation? Video generation will not work without FFmpeg. You can install it later from Settings.'
+                  )
+                ) {
+                  setFfmpegReady(true);
+                  showSuccessToast({
+                    title: 'FFmpeg Skipped',
+                    message:
+                      'Remember to install FFmpeg before creating videos. You can do this from Settings.',
+                  });
+                }
+              }}
+            >
+              Skip for Now
+            </Button>
+          </div>
+        </Card>
+      )}
     </div>
   );
 
@@ -653,7 +696,6 @@ export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
 
   const buttonLabel = 'Next';
   const buttonDisabled =
-    (state.step === 1 && !ffmpegReady) ||
     (state.step === 2 && !hasAtLeastOneProvider) ||
     state.status === 'validating' ||
     state.status === 'installing';


### PR DESCRIPTION
Unblock the first-run wizard by allowing users to skip FFmpeg installation or see installation options immediately.

The previous implementation hard-blocked users on step 2 of the onboarding wizard if FFmpeg was not detected, making the application unusable until FFmpeg was installed. This PR resolves the blocking issue by providing a "Skip for Now" option and automatically expanding FFmpeg installation details.

---
<a href="https://cursor.com/background-agent?bcId=bc-07242cbb-8758-4889-ab51-21cd4a98fed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-07242cbb-8758-4889-ab51-21cd4a98fed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

