### PR TITLE
Fix ffmpeg installation and detection in wizard

### DIFF
--- a/Aura.Web/src/components/Onboarding/__tests__/FFmpegDependencyCard.test.tsx
+++ b/Aura.Web/src/components/Onboarding/__tests__/FFmpegDependencyCard.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, beforeEach, vi, it } from 'vitest';
+vi.mock('../../../services/api/ffmpegClient', () => ({
+  ffmpegClient: {
+    getStatus: vi.fn(),
+    install: vi.fn(),
+  },
+}));
+
+import { FFmpegDependencyCard } from '../FFmpegDependencyCard';
+import type { FFmpegStatus } from '../../../services/api/ffmpegClient';
+import { ffmpegClient } from '../../../services/api/ffmpegClient';
+
+const createStatus = (overrides: Partial<FFmpegStatus> = {}): FFmpegStatus => ({
+  installed: false,
+  valid: false,
+  version: null,
+  path: null,
+  source: 'None',
+  error: null,
+  versionMeetsRequirement: false,
+  minimumVersion: '4.0',
+  hardwareAcceleration: {
+    nvencSupported: false,
+    amfSupported: false,
+    quickSyncSupported: false,
+    videoToolboxSupported: false,
+    availableEncoders: [],
+  },
+  correlationId: 'test-correlation',
+  ...overrides,
+});
+
+const mockedGetStatus = vi.mocked(ffmpegClient.getStatus);
+
+describe('FFmpegDependencyCard', () => {
+  beforeEach(() => {
+    mockedGetStatus.mockReset();
+  });
+
+  it('shows install button when FFmpeg is not ready', async () => {
+    mockedGetStatus.mockResolvedValueOnce(
+      createStatus({
+        installed: false,
+        valid: false,
+        error: 'FFmpeg not found',
+      })
+    );
+
+    render(<FFmpegDependencyCard autoCheck autoExpandDetails />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /install managed ffmpeg/i })).toBeVisible();
+    });
+  });
+
+  it('invokes onInstallComplete when FFmpeg is detected without a version', async () => {
+    const onInstallComplete = vi.fn();
+    mockedGetStatus.mockResolvedValueOnce(
+      createStatus({
+        installed: true,
+        valid: true,
+        version: null,
+        path: '/usr/bin/ffmpeg',
+        source: 'PATH',
+        versionMeetsRequirement: true,
+      })
+    );
+
+    render(
+      <FFmpegDependencyCard autoCheck autoExpandDetails onInstallComplete={onInstallComplete} />
+    );
+
+    await waitFor(() => {
+      expect(onInstallComplete).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Implement a comprehensive FFmpeg setup workflow in the first-run wizard, including install, manual path entry, and improved detection, to address user feedback on missing options and inaccurate status.

The previous FFmpeg setup in the wizard was incomplete, lacking a direct install button and robust manual path configuration. This led to user confusion when FFmpeg was detected by the backend but not reflected in the UI, or when users wanted to point to an existing installation. This PR overhauls the Step 2 UI to provide all necessary controls for a smooth FFmpeg setup experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-346d0eeb-d719-437d-b5bb-dd70f07a7ec9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-346d0eeb-d719-437d-b5bb-dd70f07a7ec9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

